### PR TITLE
Fix for incorrect version comparison

### DIFF
--- a/bin/htmlhint
+++ b/bin/htmlhint
@@ -3,6 +3,7 @@
 var program = require('commander'),
     fs = require('fs'),
     path = require('path'),
+    semver = require('semver'),
     HTMLHint  = require("../index").HTMLHint,
     pkg = require('../package.json');
 
@@ -137,7 +138,7 @@ function hintFile(filepath, ruleset){
 }
 
 function quit(code){
-    if ((!process.stdout.flush || !process.stdout.flush()) && (parseFloat(process.versions.node) < 0.5)) {
+    if ((!process.stdout.flush || !process.stdout.flush()) && semver.lt(process.versions.node,'0.5.0')) {
         process.once("drain", function () {
             process.exit(code || 0);
         });

--- a/package.json
+++ b/package.json
@@ -4,10 +4,11 @@
   "description": "A Static Code Analysis Tool for HTML",
   "main": "./index",
   "dependencies": {
-    "commander": "1.1.1",
     "colors": "0.6.0-1",
+    "commander": "1.1.1",
+    "csslint": "0.10.0",
     "jshint": "1.1.0",
-    "csslint": "0.10.0"
+    "semver": "^2.3.1"
   },
   "devDependencies": {
     "grunt-cli": "0.1.6",

--- a/test/executable.spec.js
+++ b/test/executable.spec.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 var exec = require('child_process').exec;
 
 var expect  = require("expect.js");

--- a/test/executable.spec.js
+++ b/test/executable.spec.js
@@ -1,0 +1,13 @@
+var exec = require('child_process').exec;
+
+var expect  = require("expect.js");
+
+describe('Executable', function(){
+
+  it('Executable exits correctly', function(){
+    exec( __dirname + '/../bin/htmlhint -l', function (error) {
+      expect(error).to.be(null);
+    });
+  });
+
+});


### PR DESCRIPTION
Hi,

I noticed that the HTMLHint executable hangs when exiting due to an issue with node version comparison - this pull request fixes the issue by using semver to do the comparison