### PR TITLE
Make executable process file regardless of extension

### DIFF
--- a/bin/htmlhint
+++ b/bin/htmlhint
@@ -79,7 +79,16 @@ function getAllFiles(arrTargets){
     var arrAllFiles = [];
     if(arrTargets.length > 0){
         for(var i=0,l=arrTargets.length;i<l;i++){
-            getFiles(arrTargets[i], arrAllFiles);
+            var filepath = path.resolve(process.cwd(), arrTargets[i]);
+            if(fs.existsSync(filepath) !== false){            
+              if(fs.statSync(filepath).isFile) {
+                arrAllFiles.push(filepath);
+              } else {
+                getFiles(arrTargets[i], arrAllFiles);
+              }
+            } else {
+              console.log('File %s does not exist'.red, arrTargets[i]);
+            }
         }
     }
     else{


### PR DESCRIPTION
White trying to integrate HTMLHint with SublimeLinter I found an issue with the executable for HTMLHint. As it stands HTMLHint will only process files with an .html extension (due to test on line 97 of current executable). To integrate with Sublime and allow the plugin to lint any file (e.g handlebars template etc.) I've made some changes to the executable so that if (and only if) you pass a file path via the command line it will process that file regardless of extension. If you pass nothing or a directory in it it will process files as before.

I've tried to implement the minimum to get this working, happy to discuss further, just let me know.