### PR TITLE
Correct copyright support in LICENSE.md

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -2,7 +2,7 @@
 The MIT License
 ================
 
-Copyright (c) 2014 Yanis Wang \<yanis.wang@gmail.com\>
+Copyright (c) 2014-2015 Yanis Wang \<yanis.wang@gmail.com\>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ HTMLHint is released under the MIT license:
 
 > The MIT License
 >
-> Copyright (c) 2015 Yanis Wang \< yanis.wang@gmail.com \>
+> Copyright (c) 2014-2015 Yanis Wang \< yanis.wang@gmail.com \>
 >
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
#52 Removed your copyrights for year 2014. This means anyone can copy code from 2014 and claim it's his.

This PR fixes it. In future update 2014-X.

As explained in http://stackoverflow.com/questions/2390230/do-copyright-dates-need-to-be-updated