### PR TITLE
New rule for checking single quotes

### DIFF
--- a/src/rules/attr-value-single-quotes.js
+++ b/src/rules/attr-value-single-quotes.js
@@ -13,8 +13,7 @@ HTMLHint.addRule({
                 col = event.col + event.tagName.length + 1;
             for(var i=0, l=attrs.length;i<l;i++){
                 attr = attrs[i];
-                if((attr.value !== '' && attr.quote === '"') || 
-                    (attr.value === '' && attr.quote === '"')){ 
+                if((attr.value !== '' && attr.quote === '"') || (attr.value === '' && attr.quote === '"')){
                     reporter.error('The value of attribute [ '+attr.name+' ] must be in single quotes.', event.line, col + attr.index, self, attr.raw);
                 }
             }

--- a/src/rules/attr-value-single-quotes.js
+++ b/src/rules/attr-value-single-quotes.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
+ * MIT Licensed
+ */
+HTMLHint.addRule({
+    id: 'attr-value-single-quotes',
+    description: 'Attribute values must be in single quotes.',
+    init: function(parser, reporter){
+        var self = this;
+        parser.addListener('tagstart', function(event){
+            var attrs = event.attrs,
+                attr,
+                col = event.col + event.tagName.length + 1;
+            for(var i=0, l=attrs.length;i<l;i++){
+                attr = attrs[i];
+                if((attr.value !== '' && attr.quote === '"') || 
+                    (attr.value === '' && attr.quote === '"')){ 
+                    reporter.error('The value of attribute [ '+attr.name+' ] must be in single quotes.', event.line, col + attr.index, self, attr.raw);
+                }
+            }
+        });
+    }
+});


### PR DESCRIPTION
This rule allows people to have HTMLHint check their html for single quotes instead of double quotes or no quotes at all.