### PR TITLE
make wbr end tag omissible

### DIFF
--- a/src/rules/tag-pair.js
+++ b/src/rules/tag-pair.js
@@ -8,7 +8,7 @@ HTMLHint.addRule({
     init: function(parser, reporter){
         var self = this;
         var stack=[],
-            mapEmptyTags = parser.makeMap("area,base,basefont,br,col,embed,frame,hr,img,input,isindex,keygen,link,meta,param,source,track");//HTML 4.01 + HTML5
+            mapEmptyTags = parser.makeMap("area,base,basefont,br,col,embed,frame,hr,img,input,isindex,keygen,link,meta,param,source,track,wbr");//HTML 4.01 + HTML5
         parser.addListener('tagstart', function(event){
             var tagName = event.tagName.toLowerCase();
             if (mapEmptyTags[tagName] === undefined && !event.close){


### PR DESCRIPTION
Fix issue #111 
According to HTML specification, wbr element does not have end tag -- https://html.spec.whatwg.org/#the-wbr-element