### PR TITLE
Adding support for a white list of attributes that can be lower case.

### DIFF
--- a/src/rules/attr-lowercase.js
+++ b/src/rules/attr-lowercase.js
@@ -5,8 +5,9 @@
 HTMLHint.addRule({
     id: 'attr-lowercase',
     description: 'All attribute names must be in lowercase.',
-    init: function(parser, reporter){
+    init: function(parser, reporter, options){
         var self = this;
+        var exceptions = Array.isArray(options) ? options : [];
         parser.addListener('tagstart', function(event){
             var attrs = event.attrs,
                 attr,
@@ -14,7 +15,7 @@ HTMLHint.addRule({
             for(var i=0, l=attrs.length;i<l;i++){
                 attr = attrs[i];
                 var attrName = attr.name;
-                if(attrName !== attrName.toLowerCase()){
+                if (exceptions.indexOf(attrName) === -1 && attrName !== attrName.toLowerCase()){
                     reporter.error('The attribute name of [ '+attrName+' ] must be in lowercase.', event.line, col + attr.index, self, attr.raw);
                 }
             }


### PR DESCRIPTION
When enabling the rule instead of using a boolean, use an array with the attributes (camelCased) that you want to ignore
```json
{
  "attr-lowercase": ["viewBox"]
}
```
Fixes #28