### PR TITLE
fix #119 space-tab-mixed-disabled rule issue

### DIFF
--- a/src/htmlparser.js
+++ b/src/htmlparser.js
@@ -151,6 +151,10 @@ var HTMLParser = (function(undefined){
                 self.fire(type, data);
                 var lineMatch;
                 while((lineMatch = regLine.exec(raw))){
+                    self.fire('newline', {
+                        raw: lineMatch.input,
+                        line: line
+                    });
                     line ++;
                     lastLineIndex = pos + regLine.lastIndex;
                 }

--- a/src/rules/space-tab-mixed-disabled.js
+++ b/src/rules/space-tab-mixed-disabled.js
@@ -7,7 +7,7 @@ HTMLHint.addRule({
     description: 'Do not mix tabs and spaces for indentation.',
     init: function(parser, reporter, options){
         var self = this;
-        parser.addListener('text', function(event){
+        parser.addListener('newline', function(event){
             var raw = event.raw;
             var reMixed = /(^|\r?\n)([ \t]+)/g;
             var match;

--- a/test/htmlparser.spec.js
+++ b/test/htmlparser.spec.js
@@ -375,7 +375,7 @@ describe('HTMLParser: Object parse', function(){
             expect(arrEvents[2]).to.event('cdata',
             {
                 tagName: 'script',
-                raw: 'alert(1);\r\nalert("</html>");'
+                raw: 'alert(1);alert("</html>");'
             });
             mapAttrs = parser.getMapAttrs(arrEvents[2].attrs);
             expect(mapAttrs.type).to.be('text/javascript');
@@ -385,7 +385,7 @@ describe('HTMLParser: Object parse', function(){
             });
             done();
         });
-        parser.parse('<script type="text/javascript">alert(1);\r\nalert("</html>");</script>');
+        parser.parse('<script type="text/javascript">alert(1);alert("</html>");</script>');
     });
 
 
@@ -401,7 +401,7 @@ describe('HTMLParser: Object parse', function(){
             expect(arrEvents[2]).to.event('cdata',
             {
                 tagName: 'style',
-                raw: 'body{font-size:12px;\r\nbackground-color:green;}'
+                raw: 'body{font-size:12px;background-color:green;}'
             });
             expect(arrEvents[3]).to.event('tagend',
             {
@@ -409,7 +409,7 @@ describe('HTMLParser: Object parse', function(){
             });
             done();
         });
-        parser.parse('<style type="text/css">body{font-size:12px;\r\nbackground-color:green;}</style>');
+        parser.parse('<style type="text/css">body{font-size:12px;background-color:green;}</style>');
     });
 
 });

--- a/test/rules/space-tab-mixed-disabled.spec.js
+++ b/test/rules/space-tab-mixed-disabled.spec.js
@@ -20,18 +20,18 @@ describe('Rules: '+ruldId, function(){
 
     it('Spaces and tabs mixed in front of line should result in an error', function(){
         // space before tab
-        var code = '    	<a href="a">bbb</a>';
+        var code = '\r\n    	<a href="a">bbb</a>';
         var messages = HTMLHint.verify(code, ruleMixOptions);
         expect(messages.length).to.be(1);
         expect(messages[0].rule.id).to.be(ruldId);
-        expect(messages[0].line).to.be(1);
+        expect(messages[0].line).to.be(2);
         expect(messages[0].col).to.be(1);
         // tab before space
-        code = '		 <a href="a">bbb</a>';
+        code = '\r\n		 <a href="a">bbb</a>';
         messages = HTMLHint.verify(code, ruleMixOptions);
         expect(messages.length).to.be(1);
         expect(messages[0].rule.id).to.be(ruldId);
-        expect(messages[0].line).to.be(1);
+        expect(messages[0].line).to.be(2);
         expect(messages[0].col).to.be(1);
         // multi line
         code = '<div>\r\n	 <a href="a">bbb</a>';
@@ -43,7 +43,7 @@ describe('Rules: '+ruldId, function(){
     });
 
     it('Only spaces in front of line should not result in an error', function(){
-        var code = '     <a href="a">bbb</a>';
+        var code = '\r\n     <a href="a">bbb</a>';
         var messages = HTMLHint.verify(code, ruleMixOptions);
         expect(messages.length).to.be(0);
 
@@ -53,54 +53,54 @@ describe('Rules: '+ruldId, function(){
     });
 
     it('Only tabs in front of line should not result in an error', function(){
-        var code = '			<a href="a">bbb</a>';
+        var code = '\r\n			<a href="a">bbb</a>';
         var messages = HTMLHint.verify(code, ruleMixOptions);
         expect(messages.length).to.be(0);
     });
-    
+
     it('Not only space in front of line should result in an error', function(){
         // mixed 1
-        var code = '    	<a href="a">bbb</a>';
+        var code = '\r\n    	<a href="a">bbb</a>';
         var messages = HTMLHint.verify(code, ruleSpaceOptions);
         expect(messages.length).to.be(1);
-        
+
         // mixed 2
-        code = '	    <a href="a">bbb</a>';
+        code = '\r\n	    <a href="a">bbb</a>';
         messages = HTMLHint.verify(code, ruleSpaceOptions);
         expect(messages.length).to.be(1);
-        
+
         // only tab
-        code = '		<a href="a">bbb</a>';
+        code = '\r\n		<a href="a">bbb</a>';
         messages = HTMLHint.verify(code, ruleSpaceOptions);
         expect(messages.length).to.be(1);
     });
-    
+
     it('Only space in front of line should not result in an error', function(){
-        var code = '            <a href="a">bbb</a>';
+        var code = '\r\n            <a href="a">bbb</a>';
         var messages = HTMLHint.verify(code, ruleSpaceOptions);
         expect(messages.length).to.be(0);
     });
-    
+
     it('Not only tab in front of line should result in an error', function(){
         // mixed 1
-        var code = '	    <a href="a">bbb</a>';
+        var code = '\r\n	    <a href="a">bbb</a>';
         var messages = HTMLHint.verify(code, ruleTabOptions);
         expect(messages.length).to.be(1);
-        
+
         // mixed 2
-        code = '    	<a href="a">bbb</a>';
+        code = '\r\n    	<a href="a">bbb</a>';
         messages = HTMLHint.verify(code, ruleTabOptions);
         expect(messages.length).to.be(1);
-        
+
         // only space
-        code = '       <a href="a">bbb</a>';
+        code = '\r\n       <a href="a">bbb</a>';
         messages = HTMLHint.verify(code, ruleTabOptions);
         expect(messages.length).to.be(1);
     });
-    
+
     it('Only tab in front of line should not result in an error', function(){
         // only tab
-        var code = '		<a href="a">bbb</a>';
+        var code = '\r\n		<a href="a">bbb</a>';
         var messages = HTMLHint.verify(code, ruleTabOptions);
         expect(messages.length).to.be(0);
     });


### PR DESCRIPTION
fixing #119 by fire a "newline" event when line break is found, and only when this "newline" event is fired, space-tab-mixed-disabled rule is invoked. In this way, spaces/tabs which does not belong to indentation will not be checked.