### PR TITLE
Add --warn option to exit with code 0

### DIFF
--- a/bin/htmlhint
+++ b/bin/htmlhint
@@ -54,6 +54,7 @@ program
     .option('-f, --format <'+arrSupportedFormatters.join('|')+'>', 'output messages as custom format')
     .option('-i, --ignore <pattern, pattern ...>', 'add pattern to exclude matches')
     .option('--nocolor', 'disable color')
+    .option('--warn', 'Warn only, exit with 0')
     .parse(process.argv);
 
 if(program.list){
@@ -134,7 +135,7 @@ function hintTargets(arrTargets, options){
             allHintCount: allHintCount,
             time: spendTime
         });
-        process.exit(allHintCount > 0 ? 1: 0);
+        process.exit(!program.warn && allHintCount > 0 ? 1 : 0);
     });
 }
 


### PR DESCRIPTION
`--warn` gives us the ability to exit cleanly so that other build tasks can run.

There seems to be no consistency between `reporter.error` & `reporter.warn`. Eventually it would be nice to specify which rules should warn and which should error in the config (instead of true/false)